### PR TITLE
Update requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ python-dateutil==2.2
 django-pipeline==1.3.20
 slimit==0.8.1
 django-nose==1.2
-requests==2.1.0
+requests==2.5.1
 django-cache-utils==0.7.2
 django-instant-coverage>=0.0.5
 Pillow==2.3.0


### PR DESCRIPTION
Reason for this is due to SSLv3 erroring due to being removed(?), the newer versions of requests fix this and v2.5.1 is the latest version as of this PR.