### PR TITLE
Disable autocorrect in text fields that don't need it

### DIFF
--- a/nkdsu/apps/vote/forms.py
+++ b/nkdsu/apps/vote/forms.py
@@ -11,6 +11,15 @@ from .models import Request, Note
 from ..vote import trivia
 from .utils import reading_tw_api
 
+_disable_autocorrect = {
+    "autocomplete": "off",
+    "autocorrect": "off",
+    "spellcheck": "false"
+    }
+
+_proper_noun_textinput = forms.TextInput(attrs=dict(_disable_autocorrect,
+                                                    autocapitalize="words"))
+
 
 def email_or_twitter(address):
     try:
@@ -24,7 +33,7 @@ def email_or_twitter(address):
 
 
 class EmailOrTwitterField(forms.EmailField):
-    widget = forms.TextInput
+    widget = forms.TextInput(attrs=dict(_disable_autocorrect, autocapitalize="off"))
     default_error_messages = {
         'invalid': u'Enter a valid email address or Twitter username',
     }
@@ -87,12 +96,13 @@ class BadMetadataForm(TriviaForm):
 
 
 class RequestForm(TriviaForm):
-    title = forms.CharField(required=False)
-    artist = forms.CharField(required=False)
-    show = forms.CharField(label="Source Anime", required=False)
+    title = forms.CharField(widget=_proper_noun_textinput, required=False)
+    artist = forms.CharField(widget=_proper_noun_textinput, required=False)
+    show = forms.CharField(label="Source Anime", required=False,
+                           widget=_proper_noun_textinput)
     role = forms.CharField(label="Role (OP/ED/Insert/Character/etc.)",
                            required=False)
-    details = forms.CharField(widget=forms.Textarea,
+    details = forms.CharField(widget=forms.Textarea(attrs=_disable_autocorrect),
                               label="Additional Details", required=False)
     contact = EmailOrTwitterField(label="Email Address/Twitter name",
                                   required=True)

--- a/nkdsu/templates/include/pre_content.html
+++ b/nkdsu/templates/include/pre_content.html
@@ -20,7 +20,7 @@
     </div>
     <div id="search">
       <form name="search" action="{% url "vote:search" %}" method="get">
-        <input placeholder="search" id="query" type="text" name="q" value="{{ query }}">
+        <input placeholder="search" id="query" type="text" name="q" value="{{ query }}" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
       </form>
     </div>
   </div>


### PR DESCRIPTION
Some text fields, particularly the search box, are mostly used to search non-English words by users on English phones. This means that AutoCorrect is a hindrance rather than a help. Further, on the form to request a song added to the library, in addition to having AutoCorrect disabled, it's also helpful to have Title Case enabled in many fields, since these expect names and song titles. Both of these are implemented in this PR. Additionally, AutoCorrect is disabled in the Email/Twitter field—it's possible using models.EmailWidget would do this, but I assume this is the default behaviour when inheriting from forms.EmailField, and that there is a reason that it is currently overridden with forms.TextInput.