### PR TITLE
add a new roulette mode for popular tracks

### DIFF
--- a/nkdsu/apps/vote/urls.py
+++ b/nkdsu/apps/vote/urls.py
@@ -111,7 +111,7 @@ urlpatterns = [
     url(r'^added/(?P<date>[\d-]+)/$', views.Added.as_view(), name='added'),
     url(r'^added/$', views.Added.as_view(), name='added'),
 
-    url(r'^roulette/(?P<mode>indiscriminate|hipster|almost-100|pro|popular)/$',
+    url(r'^roulette/(?P<mode>indiscriminate|hipster|almost-100|pro|staple)/$',
         views.Roulette.as_view(), name='roulette'),
     url(r'^roulette/$', views.Roulette.as_view(), name='roulette'),
 

--- a/nkdsu/apps/vote/urls.py
+++ b/nkdsu/apps/vote/urls.py
@@ -111,7 +111,7 @@ urlpatterns = [
     url(r'^added/(?P<date>[\d-]+)/$', views.Added.as_view(), name='added'),
     url(r'^added/$', views.Added.as_view(), name='added'),
 
-    url(r'^roulette/(?P<mode>indiscriminate|hipster|almost-100|pro)/$',
+    url(r'^roulette/(?P<mode>indiscriminate|hipster|almost-100|pro|popular)/$',
         views.Roulette.as_view(), name='roulette'),
     url(r'^roulette/$', views.Roulette.as_view(), name='roulette'),
 

--- a/nkdsu/apps/vote/views/__init__.py
+++ b/nkdsu/apps/vote/views/__init__.py
@@ -155,7 +155,7 @@ class Roulette(ListView):
             # since the track was made available. Exclude tracks that don't
             # yet have enough plays to be reasonably called a "staple".
 
-            usec_per_week = 3600 * 24 * 7 * 1_000_000
+            usec_per_week = 1_000_000 * 60 * 60 * 24 * 7
             qs = (
                 qs.annotate(plays=Count('play'))
                 .filter(plays__gt=2)

--- a/nkdsu/apps/vote/views/__init__.py
+++ b/nkdsu/apps/vote/views/__init__.py
@@ -91,7 +91,7 @@ class Roulette(ListView):
         ('hipster', 'hipster'),
         ('indiscriminate', 'indiscriminate'),
         ('almost-100', 'almost 100'),
-        ('popular', 'popular'),
+        ('staple', 'staple'),
         ('pro', 'pro (only for pros)'),
     ]
 
@@ -150,10 +150,10 @@ class Roulette(ListView):
                 play__date__gt=Show.current().end -
                 datetime.timedelta(days=(7 * 80)),
             ).exclude(play=None)
-        elif self.kwargs.get('mode') == 'popular':
-            # Popularity: having been played more than once per year(ish)
+        elif self.kwargs.get('mode') == 'staple':
+            # Staple track: having been played more than once per year(ish)
             # since the track was made available. Exclude tracks that don't
-            # yet have enough plays to be reasonably called "popular".
+            # yet have enough plays to be reasonably called a "staple".
 
             usec_per_week = 3600 * 24 * 7 * 1_000_000
             qs = (
@@ -325,7 +325,7 @@ class Stats(TemplateView):
             minimum_weight=minimum_weight
         ), reverse=True)
 
-    def popular_tracks(self):
+    def staple_tracks(self):
         cutoff = Show.at(timezone.now() - datetime.timedelta(days=31*6)).end
         tracks = []
 
@@ -340,7 +340,7 @@ class Stats(TemplateView):
         context.update({
             'streaks': self.streaks,
             'batting_averages': self.batting_averages,
-            'popular_tracks': self.popular_tracks,
+            'staple_tracks': self.staple_tracks,
         })
         return context
 

--- a/nkdsu/apps/vote/views/__init__.py
+++ b/nkdsu/apps/vote/views/__init__.py
@@ -1,4 +1,5 @@
 import datetime
+from random import sample
 
 import tweepy
 
@@ -11,6 +12,8 @@ from django.utils import timezone
 from django.conf import settings
 from django.core.mail import send_mail
 from django.views.generic import TemplateView, ListView, DetailView, FormView
+from django.db.models import F, Count, IntegerField, ExpressionWrapper
+from django.db.models.functions import Now
 
 from ..forms import RequestForm, BadMetadataForm
 from ..models import Show, Track, TwitterUser
@@ -88,6 +91,7 @@ class Roulette(ListView):
         ('hipster', 'hipster'),
         ('indiscriminate', 'indiscriminate'),
         ('almost-100', 'almost 100'),
+        ('popular', 'popular'),
         ('pro', 'pro (only for pros)'),
     ]
 
@@ -146,6 +150,24 @@ class Roulette(ListView):
                 play__date__gt=Show.current().end -
                 datetime.timedelta(days=(7 * 80)),
             ).exclude(play=None)
+        elif self.kwargs.get('mode') == 'popular':
+            # Popularity: having been played more than once per year(ish)
+            # since the track was made available. Exclude tracks that don't
+            # yet have enough plays to be reasonably called "popular".
+
+            usec_per_week = 3600 * 24 * 7 * 1_000_000
+            qs = (
+                qs.annotate(plays=Count('play'))
+                .filter(plays__gt=2)
+                .annotate(
+                    weeks_per_play=ExpressionWrapper(
+                        ((Now() - F('revealed')) / F('plays') / usec_per_week),
+                        output_field=IntegerField()
+                    )
+                ).filter(weeks_per_play__lt=52)
+            )
+            # order_by('?') fails when annotate() has been used
+            return sample(list(qs), 5)
 
         return qs.order_by('?')[:5]
 


### PR DESCRIPTION
these tracks have been played more than once per year on average since being added.
becaue this depends on filtering on annotations, which breaks `order_by('?')`, `random.sample` is used instead for this case only. (for indiscriminate roulette this would require getting all N-thousand tracks from the queryset which would probably have performance implications.)

the name “popular roulette” was chosen over “banger roulette” because some tracks are not certified bangers (some may be jams or bops), while some certified bangers will not meet the inclusion criterion here. 